### PR TITLE
fix: allow rerender on node prop change

### DIFF
--- a/src/PageSwapper.js
+++ b/src/PageSwapper.js
@@ -56,7 +56,7 @@ export default class PageSwapper extends Component {
                 { nodeKey && (
                     <SwapTransition
                         key={ nodeKey }
-                        node={ node }
+                        node={ !this.isOutOfSync() && !this.isSwapping() ? this.props.node : node }
                         nodeKey={ nodeKey }
                         hasPrevNode={ !!prevNodeKey }
                         animation={ animation }


### PR DESCRIPTION
This PR aims to fix a bug where node props change wouldn't trigger a rerender. This was caused because the node prop was being stored in the `PageSwapper` state and not being properly updated.

Firstly i thought in a solution that would be essentially making state checks in `ComponentDidUpdate` but this was obviously causing an extra rendering. So for now i'm using the prop `node` directly instead of using the state as long as it's not interfering with the swap behaviour.

Open for discussion